### PR TITLE
add changes and destroy lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@angular/common": "^11.0.2",
     "@angular/compiler": "^11.0.2",
     "@angular/compiler-cli": "^11.0.2",
-    "@angular/core": "^10.0.2",
+    "@angular/core": "^11.0.2",
     "@swc/core": "^1.2.39",
     "aria-build": "^0.6.1",
     "aria-fs": "^0.6.1",

--- a/src/element.ts
+++ b/src/element.ts
@@ -25,7 +25,13 @@ export class NgxElement<T> extends HTMLElement  {
   attributeChangedCallback(name: string, oldValue: any, newValue: any) {
     if (this.schema.attrs.includes(name)) {
       this[name] = newValue
-    }      
+    }
+  }
+
+  disconnectedCallback() {
+    if (this.component['ngOnDestroy']) {
+      this.component['ngOnDestroy'].bind(this.component)();
+    }
   }
 
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,25 @@
 import { NgxElement } from './element'
 
 export function initProps<T>(target: NgxElement<T>) {
+  const propsFirstChange = {};
   target.schema.attrs.forEach(key => {
     Object.defineProperty(target, key, {
       get() { 
         return target.component[key] 
       },
       set(value) {
-        target.component[key] = value
+        const oldValue =  target.component[key];
+        target.component[key] = value;
+        if (target.component['ngOnChanges']) {
+          target.component['ngOnChanges'].bind(target.component)({
+            [key]: {
+              previousValue: oldValue,
+              currentValue: value,
+              first: !propsFirstChange[key]
+            }
+          });
+        }
+        propsFirstChange[key] = true;
       }
     })
   })


### PR DESCRIPTION
After some tests, I seen `ngOnChanges` and `ngOnDestroy` was never called.
I made a bridge with the default lifecycle functions `attributeChangedCallback ` and `disconnectedCallback `.